### PR TITLE
fix!: Return an empty enumerable instead of throwing an exception

### DIFF
--- a/src/Core/Configuration/CPluginConfigurationBase.cs
+++ b/src/Core/Configuration/CPluginConfigurationBase.cs
@@ -13,11 +13,11 @@ public abstract class CPluginConfigurationBase
     /// Gets the full path to each plugin file from a configuration source.
     /// </summary>
     /// <returns>
-    /// A collection of plugin files that also contains the paths.
+    /// A collection of plugin files that also contains the paths;
+    /// <para>or</para>
+    /// Returns an empty enumerable when the plugin files could not be obtained.
+    /// <para>This method never returns <c>null</c>.</para>
     /// </returns>
-    /// <exception cref="InvalidOperationException">
-    /// Failed to extract plugin names.
-    /// </exception>
     /// <remarks>
     /// Plugin files must be in the <c>plugins</c> directory of the current directory 
     /// where the host application is running.

--- a/src/Core/Configuration/CPluginEnvConfiguration.cs
+++ b/src/Core/Configuration/CPluginEnvConfiguration.cs
@@ -22,18 +22,11 @@ public class CPluginEnvConfiguration : CPluginConfigurationBase
     /// <inheritdoc />
     public override IEnumerable<string> GetPluginFiles()
     {
-        var recoveredValue = Environment.GetEnvironmentVariable("PLUGINS");
-        if(recoveredValue is null)
-        {
-            var message =
-            """
-            'PLUGINS' environment variable is not set.
-            Please check the export command or the .env file.
-            """;
-            throw new InvalidOperationException(message);
-        }
+        var retrievedValue = Environment.GetEnvironmentVariable("PLUGINS");
+        if(retrievedValue is null)
+            return Enumerable.Empty<string>();
 
-        var pluginFiles = recoveredValue
+        var pluginFiles = retrievedValue
             .Split(" ")
             .Where(pluginFile => !string.IsNullOrWhiteSpace(pluginFile))
             .Select(GetPluginPath);

--- a/src/Core/Configuration/CPluginJsonConfiguration.cs
+++ b/src/Core/Configuration/CPluginJsonConfiguration.cs
@@ -39,19 +39,12 @@ public class CPluginJsonConfiguration : CPluginConfigurationBase
     /// <inheritdoc />
     public override IEnumerable<string> GetPluginFiles()
     {
-        var recoveredSection = _configuration.GetSection("Plugins").Get<string[]>();
-        if(recoveredSection is null)
-        {
-            var message =
-            """
-            'Plugins' section not found in json file.
-            Example:
-            {
-                "Plugins": [ "MyPlugin1.dll", "MyPlugin2.dll" ]
-            }
-            """;
-            throw new InvalidOperationException(message);
-        }
-        return recoveredSection.Select(GetPluginPath);
+        var values = _configuration
+            .GetSection("Plugins")
+            .Get<string[]>();
+
+        return values is null ? 
+            Enumerable.Empty<string>() :
+            values.Select(GetPluginPath);
     }
 }


### PR DESCRIPTION
Resolves #6, #7

`GetPluginFiles` method must not throw **InvalidOperationException**.
It must return an empty enumerable when the plugin files could not be obtained.