### PR TITLE
chore: Runs tests from the specified assemblied

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Test 
       run: |
         dotnet test ./tests/CPlugin.Net/CPlugin.Net.Tests.csproj -c Release
-        dotnet publish ./tests/CPlugin.Net/CPlugin.Net.Tests.csproj -c Release -o out
+        dotnet publish ./tests/CPlugin.Net/CPlugin.Net.Tests.csproj -c Release --no-build -o out
         dotnet vstest ./out/CPlugin.Net.Tests.dll
         dotnet build ./samples/Plugins/AppointmentPlugin/Example.AppointmentPlugin.csproj -c Release
         dotnet build ./samples/Plugins/PersonPlugin/Example.PersonPlugin.csproj -c Release

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -24,6 +24,8 @@ jobs:
     - name: Test 
       run: |
         dotnet test ./tests/CPlugin.Net/CPlugin.Net.Tests.csproj -c Release
+        dotnet publish ./tests/CPlugin.Net/CPlugin.Net.Tests.csproj -c Release -o out
+        dotnet vstest ./out/CPlugin.Net.Tests.dll
         dotnet build ./samples/Plugins/AppointmentPlugin/Example.AppointmentPlugin.csproj -c Release
         dotnet build ./samples/Plugins/PersonPlugin/Example.PersonPlugin.csproj -c Release
         dotnet build ./samples/Plugins/JsonPlugin/Example.JsonPlugin.csproj -c Release

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,6 +10,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="7.0.10" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageVersion Include="SimpleResults.AspNetCore" Version="1.0.0" />
+    <PackageVersion Include="DotEnv.Core.Props" Version="1.0.1" />
     <PackageVersion Include="DotEnv.Core" Version="3.0.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.3" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />

--- a/tests/CPlugin.Net/CPlugin.Net.Tests.csproj
+++ b/tests/CPlugin.Net/CPlugin.Net.Tests.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <PackageReference Include="CopyPluginsToPublishDirectory" />
     <PackageReference Include="DotEnv.Core" />
+    <PackageReference Include="DotEnv.Core.Props" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />

--- a/tests/CPlugin.Net/CPlugin.Net.Tests.csproj
+++ b/tests/CPlugin.Net/CPlugin.Net.Tests.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="CopyPluginsToPublishDirectory" />
     <PackageReference Include="DotEnv.Core" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
     <PackageReference Include="FluentAssertions" />


### PR DESCRIPTION
This pull request has been created to check if the nuget package called [CopyPluginsToPublishDirectory](https://www.nuget.org/packages/CopyPluginsToPublishDirectory) copies the plugins directory to the publish directory when using the **dotnet publish** command.

These two lines do the checking:
```sh
dotnet publish ./tests/CPlugin.Net/CPlugin.Net.Tests.csproj -c Release --no-build -o out
dotnet vstest ./out/CPlugin.Net.Tests.dll
```