### PR TITLE
Implement Plugin Dependency Validation to Avoid Missing Plugins

### DIFF
--- a/src/Core/Configuration/CPluginConfigurationBase.cs
+++ b/src/Core/Configuration/CPluginConfigurationBase.cs
@@ -28,6 +28,24 @@ public abstract class CPluginConfigurationBase
     public abstract IEnumerable<string> GetPluginFiles();
 
     /// <summary>
+    /// Gets the full path to each plugin file from a configuration source.
+    /// </summary>
+    /// <returns>
+    /// A collection of plugin files that also contains the paths;
+    /// <para>or</para>
+    /// Returns an empty enumerable when the plugin files could not be obtained.
+    /// <para>This method never returns <c>null</c>.</para>
+    /// </returns>
+    /// <remarks>
+    /// Plugin files must be in the <c>plugins</c> directory of the current directory 
+    /// where the host application is running.
+    /// <para>Each plugin file must have a <c>.dll</c> extension and must be in its own directory.</para>
+    /// <para>Example:</para>
+    /// <c>/HostApp/bin/Debug/net7.0/plugins/MyPlugin1/MyPlugin1.dll</c>
+    /// </remarks>
+    public abstract IEnumerable<PluginConfig> GetPluginConfigFiles();
+
+    /// <summary>
     /// Gets the full path of a plugin file.
     /// </summary>
     /// <remarks>

--- a/src/Core/Configuration/CPluginEnvConfiguration.cs
+++ b/src/Core/Configuration/CPluginEnvConfiguration.cs
@@ -21,6 +21,11 @@ public class CPluginEnvConfiguration : CPluginConfigurationBase
     /// </summary>
     public CPluginEnvConfiguration() { }
 
+    public override IEnumerable<PluginConfig> GetPluginConfigFiles()
+    {
+        throw new NotImplementedException();
+    }
+
     /// <inheritdoc />
     public override IEnumerable<string> GetPluginFiles()
     {

--- a/src/Core/Configuration/CPluginEnvConfiguration.cs
+++ b/src/Core/Configuration/CPluginEnvConfiguration.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-
-namespace CPlugin.Net;
+﻿namespace CPlugin.Net;
 
 /// <summary>
 /// Represents a configuration to get the plugin files from an environment variable.
@@ -14,8 +10,9 @@ namespace CPlugin.Net;
 /// <para>if you have plugins with dependencies, you can do this:</para>
 /// <c>
 /// PLUGINS="
-///	MyPlugin1.dll->MyPlugin2.dll
+///	MyPlugin1.dll->MyPlugin2.dll,MyPlugin3.dll
 /// MyPlugin2.dll
+/// MyPlugin3.dll
 ///"
 /// </c>
 /// </remarks>

--- a/src/Core/Configuration/CPluginJsonConfiguration.cs
+++ b/src/Core/Configuration/CPluginJsonConfiguration.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.Extensions.Configuration;
+﻿using Microsoft.Extensions.Configuration;
 
 namespace CPlugin.Net;
 
@@ -32,6 +29,11 @@ public class CPluginJsonConfiguration : CPluginConfigurationBase
     {
         ArgumentNullException.ThrowIfNull(configuration);
         _configuration = configuration;
+    }
+
+    public override IEnumerable<PluginConfig> GetPluginConfigFiles()
+    {
+        throw new NotImplementedException();
     }
 
     /// <inheritdoc />

--- a/src/Core/Configuration/CPluginJsonConfiguration.cs
+++ b/src/Core/Configuration/CPluginJsonConfiguration.cs
@@ -11,7 +11,7 @@ namespace CPlugin.Net;
 /// <c>
 /// { "Plugins": [ "MyPlugin1.dll", "MyPlugin2.dll" ] }
 /// </c>
-/// <para>if you uses dependencies:</para>
+/// <para>if you have plugins with dependencies, you can do this:</para>
 /// <c>
 /// {
 /// "Plugins": [

--- a/src/Core/Configuration/CPluginJsonConfiguration.cs
+++ b/src/Core/Configuration/CPluginJsonConfiguration.cs
@@ -11,6 +11,23 @@ namespace CPlugin.Net;
 /// <c>
 /// { "Plugins": [ "MyPlugin1.dll", "MyPlugin2.dll" ] }
 /// </c>
+/// <para>if you uses dependencies:</para>
+/// <c>
+/// {
+/// "Plugins": [
+///    {
+///       "Name": "TestProject.JsonPlugin",
+///       "DependsOn": [
+///         "TestProject.OldJsonPlugin"
+///       ]
+///     },
+///     {
+///       "Name": "TestProject.OldJsonPlugin",
+///       "DependsOn": []
+///     }
+///   ]
+/// }
+/// </c>
 /// </remarks>
 public class CPluginJsonConfiguration : CPluginConfigurationBase
 {

--- a/src/Core/Configuration/CPluginJsonConfiguration.cs
+++ b/src/Core/Configuration/CPluginJsonConfiguration.cs
@@ -33,7 +33,15 @@ public class CPluginJsonConfiguration : CPluginConfigurationBase
 
     public override IEnumerable<PluginConfig> GetPluginConfigFiles()
     {
-        throw new NotImplementedException();
+        var values = _configuration
+            .GetSection("Plugins")
+            .Get<PluginConfig[]>();
+
+        return values is null ? [] : values.Select(p => new PluginConfig
+        {
+            Name  = GetPluginPath(p.Name),
+            DependsOn = p.DependsOn
+        });
     }
 
     /// <inheritdoc />

--- a/src/Core/Configuration/PluginConfig.cs
+++ b/src/Core/Configuration/PluginConfig.cs
@@ -1,0 +1,6 @@
+﻿namespace CPlugin.Net;
+public class PluginConfig
+{
+    public string Name { get; set; } = string.Empty;
+    public List<string> DependsOn { get; set; } = [];
+}

--- a/src/Core/Exceptions/PluginNotFoundException.cs
+++ b/src/Core/Exceptions/PluginNotFoundException.cs
@@ -1,0 +1,10 @@
+﻿namespace CPlugin.Net.Exceptions;
+/// <summary>
+/// Represents an exception that is thrown when a plugin is not found.
+/// </summary>
+/// <param name="missingPlugin"> The missing plugin. </param>
+/// <param name="dependentPlugin"> The dependent plugin. </param>
+public class PluginNotFoundException(string missingPlugin, string dependentPlugin) 
+    : Exception($"The plugin '{dependentPlugin}' depends on '{missingPlugin}', but '{missingPlugin}' was not found.")
+{
+}

--- a/src/Core/PluginLoader.cs
+++ b/src/Core/PluginLoader.cs
@@ -43,7 +43,27 @@ public static class PluginLoader
         }
     }
 
+    /// <summary>
+    /// Loads plugins and their dependencies from a specified configuration source.
+    /// The plugin list can be retrieved from a JSON file, an environment variable (.env), or another configuration source.
+    /// This method ensures that all required dependencies are resolved before loading a plugin.
+    /// </summary>
+    /// <param name="configuration">
+    /// A configuration source that provides the list of plugin files and their dependencies.
+    /// </param>
+    /// <remarks>
+    /// This method is idempotent, meaning that if it is called multiple times, 
+    /// it will not reload assemblies that have already been loaded.
+    /// If a plugin depends on another plugin that is missing, a <see cref="PluginNotFoundException"/> is thrown.
+    /// </remarks>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="configuration"/> is <c>null</c>.
+    /// </exception>
+    /// <exception cref="PluginNotFoundException">
+    /// Thrown when a required plugin dependency is missing.
+    /// </exception>
     public static void LoadPluginsWithDependencies(CPluginConfigurationBase configuration)
+
     {
         ArgumentNullException.ThrowIfNull(configuration);
         var pluginConfigs = configuration.GetPluginConfigFiles();

--- a/tests/CPlugin.Net/Core/CPluginEnvConfigurationTests.cs
+++ b/tests/CPlugin.Net/Core/CPluginEnvConfigurationTests.cs
@@ -88,6 +88,38 @@ public class CPluginEnvConfigurationTests
     }
 
     [Test]
+    public void GetPluginConfigFiles_WhenPluginFilesAreObtainedFromEnvFile_ShouldReturnsFullPaths()
+    {
+        // Arrange
+        new EnvLoader()
+            .AllowOverwriteExistingVars()
+            .EnableFileNotFoundException()
+            .AddEnvFile("./Resources/testwithdependencies.env")
+            .Load();
+        var envConfiguration = new CPluginEnvConfiguration();
+        var basePath = AppContext.BaseDirectory;
+        PluginConfig[] expectedPaths =
+        [
+            new PluginConfig
+            {
+                Name = Path.Combine(basePath, "plugins", "TestProject.OldJsonPlugin", "TestProject.OldJsonPlugin.dll"),
+                DependsOn = []
+            },
+            new PluginConfig
+            {
+                Name = Path.Combine(basePath, "plugins", "TestProject.JsonPlugin", "TestProject.JsonPlugin.dll"),
+                DependsOn = ["TestProject.OldJsonPlugin.dll"]
+            },
+        ];
+
+        // Act
+        var actual = envConfiguration.GetPluginConfigFiles().ToList();
+
+        // Assert
+        actual.Should().BeEquivalentTo(expectedPaths);
+    }
+
+    [Test]
     public void GetPluginFiles_WhenPluginFilesAreNotPresent_ShouldReturnsEmptyEnumerable()
     {
         // Arrange

--- a/tests/CPlugin.Net/Core/CPluginJsonConfigurationTests.cs
+++ b/tests/CPlugin.Net/Core/CPluginJsonConfigurationTests.cs
@@ -80,6 +80,34 @@ public class CPluginJsonConfigurationTests
     }
 
     [Test]
+    public void GetPluginConfigFiles_WhenPluginFilesArePresent_ShouldReturnsFullPaths()
+    {
+        // Arrange
+        var configurationRoot = new ConfigurationBuilder()
+            .AddJsonFile("./Resources/settingsWithDependencies.json")
+            .Build();
+        var jsonConfiguration = new CPluginJsonConfiguration(configurationRoot);
+        var basePath = AppContext.BaseDirectory;
+        PluginConfig[] expectedPaths =
+        [
+            new PluginConfig
+            {
+                Name = Path.Combine(basePath, "plugins", "TestProject.OldJsonPlugin", "TestProject.OldJsonPlugin.dll"),
+                DependsOn = []
+            },
+            new PluginConfig
+            {
+                Name = Path.Combine(basePath, "plugins", "TestProject.JsonPlugin", "TestProject.JsonPlugin.dll"),
+                DependsOn = ["TestProject.OldJsonPlugin"]
+            },
+        ];
+        // Act
+        var actual = jsonConfiguration.GetPluginConfigFiles().ToList();
+        // Assert
+        actual.Should().BeEquivalentTo(expectedPaths);
+    }
+
+    [Test]
     public void Constructor_WhenArgumentIsNull_ShouldThrowArgumentNullException()
     {
         // Arrange

--- a/tests/CPlugin.Net/Core/PluginLoaderTests.cs
+++ b/tests/CPlugin.Net/Core/PluginLoaderTests.cs
@@ -158,6 +158,7 @@ public class PluginLoaderTests
         // Act
         PluginLoader.LoadPluginsWithDependencies(envConfiguration);
 
+        // Assert
         AppDomain
             .CurrentDomain
             .GetAssemblies()

--- a/tests/CPlugin.Net/Resources/settingsWithDependencies.json
+++ b/tests/CPlugin.Net/Resources/settingsWithDependencies.json
@@ -1,0 +1,14 @@
+{
+  "Plugins": [
+    {
+      "Name": "TestProject.JsonPlugin",
+      "DependsOn": [
+        "TestProject.OldJsonPlugin"
+      ]
+    },
+    {
+      "Name": "TestProject.OldJsonPlugin",
+      "DependsOn": []
+    }
+  ]
+}

--- a/tests/CPlugin.Net/Resources/testwithdependencies.env
+++ b/tests/CPlugin.Net/Resources/testwithdependencies.env
@@ -1,0 +1,4 @@
+PLUGINS="
+	TestProject.JsonPlugin.dll->TestProject.OldJsonPlugin.dll
+	TestProject.OldJsonPlugin.dll
+"


### PR DESCRIPTION
This PR enhances the plugin loading system by ensuring that plugins with dependencies are loaded correctly. If a plugin requires another plugin to function, the system will now validate its existence before proceeding. If a required dependency is missing, a PluginNotFoundException is thrown to prevent partial or broken plugin execution.

### **Why This Feature?**
Previously, the system assumed that all plugins listed in the configuration were valid and did not check for missing dependencies. This could lead to runtime failures or unexpected behavior when a plugin tried to reference another plugin that wasn't loaded. By adding explicit dependency resolution, we:

Prevent runtime errors due to missing dependencies.
Improve plugin management by making dependency requirements clear.
Allow safer dynamic loading of plugins.
Ensure that plugin loading is idempotent and efficient.
### **Key Changes:**
  ✅ Added dependency validation before loading a plugin.
  ✅ Throws PluginNotFoundException if a required dependency is missing.
  ✅ Updated the LoadPluginsWithDependencies method to check dependencies before loading.
  ✅ Improved XML documentation to clarify method behavior and expectations.
  ✅ Added unit tests to verify correct plugin dependency resolution.

### **Impact & Compatibility:**
This change does not break existing functionality but enhances it by ensuring plugins are loaded in the correct order.
If a plugin is missing a required dependency, an exception is now thrown instead of failing silently.
Existing users will need to ensure that all dependencies are correctly listed in their configuration files.